### PR TITLE
Pin awscc to the version that works

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ output "console_web_address" {
 output "username" {
   value = module.cloud-storage-security.username
 }
+```
 Additionally the module provides the outputs for use in the linked account sub-module used to link an additional AWS account to the main Cloud Storage Security (CSS) deployment.
 
 ## Solution Cleanup / Uninstall

--- a/main.tf
+++ b/main.tf
@@ -6,7 +6,7 @@ terraform {
     }
     awscc = {
       source  = "hashicorp/awscc"
-      version = "~> 0.1"
+      version = "= 0.71.0"
     }
   }
 }


### PR DESCRIPTION
Awscc provider released a version that breaks the `requires`  property for the AppConfig Document 🥲 
Pinning the provider to the last version that worked for now. 

Also small readme formatting fix