### PR TITLE
Css 1140 css 1135 fixes

### DIFF
--- a/dynamodb.tf
+++ b/dynamodb.tf
@@ -21,6 +21,29 @@ resource "aws_dynamodb_table" "buckets" {
   )
 }
 
+resource "aws_dynamodb_table" "dashboard_reports" {
+  name         = "${local.application_id}.Reports"
+  billing_mode = "PAY_PER_REQUEST"
+  hash_key     = "Id"
+  point_in_time_recovery {
+    enabled = aws_ssm_parameter.dynamo_point_in_time_recovery_enabled.value
+  }
+
+  attribute {
+    name = "Id"
+    type = "S"
+  }
+
+  server_side_encryption {
+    enabled     = local.use_dynamo_cmk
+    kms_key_arn = var.dynamo_cmk_key_arn
+  }
+
+  tags = merge({ (local.application_tag_key) = "DynamoTable" },
+    var.custom_resource_tags
+  )
+}
+
 resource "aws_dynamodb_table" "efs_volumes" {
   name         = "${local.application_id}.EfsVolumes"
   billing_mode = "PAY_PER_REQUEST"

--- a/ecs_task_definition.tf
+++ b/ecs_task_definition.tf
@@ -97,7 +97,7 @@ resource "aws_ecs_task_definition" "console" {
         { "name" : "DEPLOYMENT_TYPE", "value" : "terraform" },
         { "name" : "BUCKETS_TO_PROTECT", "value" : "${var.buckets_to_protect}" },
         { "name" : "LOG_LEVEL", "value" : "Info" },
-        { "name" : "DASHBOARD_REPORTS_BUCKET_NAME", "value": aws_s3_bucket.dashboard_reports_bucket.id},
+        { "name" : "DASHBOARD_REPORTS_BUCKET_NAME", "value" : aws_s3_bucket.dashboard_reports_bucket.id },
         { "name" : "RETRY_COUNT", "value" : "5" },
         { "name" : "RETRY_MEDIAN_JITTER_DELAY", "value" : "1" },
       ]

--- a/ecs_task_definition.tf
+++ b/ecs_task_definition.tf
@@ -27,7 +27,7 @@ resource "aws_ecs_task_definition" "console" {
         { "name" : "CONSOLE_VPC", "value" : var.vpc },
         { "name" : "CONSOLE_SUBNET", "value" : "${var.subnet_a_id},${var.subnet_b_id}" },
         { "name" : "PARAMETER_STORE_NAME_PREFIX", "value" : "/${var.parameter_prefix}-${local.application_id}" },
-        { "name" : "CONSOLE_SECURITY_GROUP_ID", "value" : "${var.configure_load_balancer}" ? "${aws_security_group.console_with_load_balancer[0].id}" : "${aws_security_group.console[0].id}" },
+        { "name" : "CONSOLE_SECURITY_GROUP_ID", "value" : "${var.configure_load_balancer}" ? "${aws_security_group.load_balancer[0].id}" : "${aws_security_group.console[0].id}" },
         { "name" : "AGENT_AUTO_ASSIGN_PUBLIC_IP", "value" : "${var.agent_auto_assign_public_ip}" ? "ENABLED" : "DISABLED" },
         { "name" : "BYOL_MODE", "value" : "False" },
         { "name" : "BLANKET_KMS_ACCESS", "value" : "${tostring(var.allow_access_to_all_kms_keys)}" },
@@ -97,6 +97,7 @@ resource "aws_ecs_task_definition" "console" {
         { "name" : "DEPLOYMENT_TYPE", "value" : "terraform" },
         { "name" : "BUCKETS_TO_PROTECT", "value" : "${var.buckets_to_protect}" },
         { "name" : "LOG_LEVEL", "value" : "Info" },
+        { "name" : "DASHBOARD_REPORTS_BUCKET_NAME", "value": aws_s3_bucket.dashboard_reports_bucket.id},
         { "name" : "RETRY_COUNT", "value" : "5" },
         { "name" : "RETRY_MEDIAN_JITTER_DELAY", "value" : "1" },
       ]

--- a/iam.tf
+++ b/iam.tf
@@ -176,6 +176,8 @@ resource "aws_iam_role_policy" "console_task" {
           "logs:GetQueryResults",
           "logs:PutLogEvents",
           "logs:*Query",
+          "logs:ListTagsForResource",
+          "logs:TagResource",
           "s3:CreateBucket",
           "s3:GetBucket*",
           "s3:Get*Configuration",

--- a/locals.tf
+++ b/locals.tf
@@ -30,4 +30,5 @@ locals {
   cross_account_role_name   = "${var.service_name}RemoteRole-${local.application_id}"
   cross_account_policy_name = "${var.service_name}RemotePolicy-${local.application_id}"
   ssm_path_prefix           = "${var.parameter_prefix}-${local.application_id}"
+  reports_bucket_name       = "${var.dashboard_reports_bucket_prefix}-${local.application_id}-${local.account_id}-${local.aws_region}"
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -14,6 +14,11 @@ output "proactive_notifications_topic_arn" {
   value       = aws_sns_topic.notifications.arn
 }
 
+output "lb_arn" {
+  description = "ARN for the console Load Balancer if LB is used"
+  value = var.configure_load_balancer && var.existing_target_group_arn == null ? aws_lb.main[0].arn : null
+}
+
 # ---------------------------------------------------------------------------------------------------------------------
 # These outputs are provided for convenience to be used in the linked account module.
 # ---------------------------------------------------------------------------------------------------------------------

--- a/outputs.tf
+++ b/outputs.tf
@@ -16,7 +16,7 @@ output "proactive_notifications_topic_arn" {
 
 output "lb_arn" {
   description = "ARN for the console Load Balancer if LB is used"
-  value = var.configure_load_balancer && var.existing_target_group_arn == null ? aws_lb.main[0].arn : null
+  value       = var.configure_load_balancer && var.existing_target_group_arn == null ? aws_lb.main[0].arn : null
 }
 
 # ---------------------------------------------------------------------------------------------------------------------

--- a/s3.tf
+++ b/s3.tf
@@ -1,0 +1,3 @@
+resource "aws_s3_bucket" "dashboard_reports_bucket" {
+  bucket = local.reports_bucket_name
+}

--- a/security_group.tf
+++ b/security_group.tf
@@ -1,5 +1,6 @@
 resource "aws_security_group" "console" {
   count       = var.configure_load_balancer ? 0 : 1
+  name        = "${var.service_name}ConsoleSecurityGroup-${local.application_id}"
   description = "${var.service_name}ConsoleSecurityGroup-${local.application_id}"
   vpc_id      = var.vpc
 
@@ -32,7 +33,8 @@ resource "aws_security_group" "console" {
 
 resource "aws_security_group" "console_with_load_balancer" {
   count       = var.configure_load_balancer ? 1 : 0
-  description = "${var.service_name}LBSecurityGroup-${local.application_id}"
+  name        = "${var.service_name}ContainerSecurityGroupWithLB-${local.application_id}"
+  description = "${var.service_name}ContainerSecurityGroupWithLB-${local.application_id}"
   vpc_id      = var.vpc
 
   ingress {
@@ -65,7 +67,8 @@ resource "aws_security_group" "console_with_load_balancer" {
 
 resource "aws_security_group" "load_balancer" {
   count       = var.configure_load_balancer ? 1 : 0
-  description = "${var.service_name}LBSecurityGroup-${local.application_id}"
+  name = "${var.service_name}LoadBalancerSecurityGroup-${local.application_id}"
+  description = "${var.service_name}LoadBalancerSecurityGroup-${local.application_id}"
   vpc_id      = var.vpc
 
   ingress {

--- a/security_group.tf
+++ b/security_group.tf
@@ -29,6 +29,11 @@ resource "aws_security_group" "console" {
   tags = merge({ (local.application_tag_key) = "SecurityGroup" },
     var.custom_resource_tags
   )
+  lifecycle {
+    ignore_changes = [
+      name
+    ]
+  }
 }
 
 resource "aws_security_group" "console_with_load_balancer" {
@@ -63,6 +68,11 @@ resource "aws_security_group" "console_with_load_balancer" {
   tags = merge({ (local.application_tag_key) = "SecurityGroup" },
     var.custom_resource_tags
   )
+  lifecycle {
+    ignore_changes = [
+      name
+    ]
+  }
 }
 
 resource "aws_security_group" "load_balancer" {

--- a/security_group.tf
+++ b/security_group.tf
@@ -67,7 +67,7 @@ resource "aws_security_group" "console_with_load_balancer" {
 
 resource "aws_security_group" "load_balancer" {
   count       = var.configure_load_balancer ? 1 : 0
-  name = "${var.service_name}LoadBalancerSecurityGroup-${local.application_id}"
+  name        = "${var.service_name}LoadBalancerSecurityGroup-${local.application_id}"
   description = "${var.service_name}LoadBalancerSecurityGroup-${local.application_id}"
   vpc_id      = var.vpc
 

--- a/ssm.tf
+++ b/ssm.tf
@@ -229,12 +229,18 @@ resource "aws_ssm_parameter" "agent_scanning_engine" {
   name  = "/${local.ssm_path_prefix}/Config/AgentScanningEngine"
   type  = "String"
   value = var.agent_scanning_engine
+  lifecycle {
+    ignore_changes = [value]
+  }
 }
 
 resource "aws_ssm_parameter" "multi_engine_scanning_mode" {
   name  = "/${local.ssm_path_prefix}/Config/MultiEngineScanningMode"
   type  = "String"
   value = var.multi_engine_scanning_mode
+  lifecycle {
+    ignore_changes = [value]
+  }
 }
 
 resource "aws_ssm_parameter" "ecr_account_id" {

--- a/variables.tf
+++ b/variables.tf
@@ -100,19 +100,28 @@ variable "internal_lb" {
 }
 
 variable "min_running_agents" {
-  description = "Default minimum number of running scan agents per region"
+  description = <<EOF
+  Initial default minimum number of running scan agents per region
+  This value represents the initial setting upon deployment and can be modified via the console's UI after the initial deployment using Terraform.
+  EOF
   type        = number
   default     = 1
 }
 
 variable "max_running_agents" {
-  description = "Default maximum number of running scan agents per region"
+  description = <<EOF
+  Default maximum number of running scan agents per region.
+  This value represents the initial setting upon deployment and can be modified via the console's UI after the initial deployment using Terraform.
+  EOF
   type        = number
   default     = 12
 }
 
 variable "enable_large_file_scanning" {
-  description = "Set to true if you would like to have EC2 instances launched to scan files too large to be scanned by the normal agent"
+  description = <<EOF
+  Set to true if you would like to have EC2 instances launched to scan files too large to be scanned by the normal agent
+  This value represents the initial setting upon deployment and can be modified via the console's UI after the initial deployment using Terraform.
+  EOF
   type        = bool
   default     = false
 }
@@ -121,6 +130,7 @@ variable "large_file_disk_size_gb" {
   description = <<EOF
     Choose a larger disk size (between 20 - 16,300 GB) to enable scanning larger files, up to 5 GB fewer than the total disk size. 
     This only applies when using the Sophos scanning engine with EC2 large file scanning enabled.
+    This value represents the initial setting upon deployment and can be modified via the console's UI after the initial deployment using Terraform.
   EOF
   type        = number
   default     = 2000
@@ -128,8 +138,9 @@ variable "large_file_disk_size_gb" {
 
 variable "agent_scanning_engine" {
   description = <<EOF
-    The scanning engine to use. ClamAV is included with no additional charges.
-    Premium engines such as `Sophos` incurr an additional licensing charge per GB (see Marketplace listing for pricing) Valid values: `ClamAV`, `Sophos`
+    The initial scanning engine to use. ClamAV is included with no additional charges.
+    Premium engines such as `Sophos` incur an additional licensing charge per GB (see Marketplace listing for pricing) Valid values: `ClamAV`, `Sophos`
+    This value represents the initial setting upon deployment and can be modified via the console's UI after the initial deployment using Terraform.
   EOF
   type        = string
   default     = "ClamAV"
@@ -137,10 +148,11 @@ variable "agent_scanning_engine" {
 
 variable "multi_engine_scanning_mode" {
   description = <<EOF
-    Whether or not multiple av engines should be utilized to scan files. If this is enabled, the `agent_scanning_engine` variable must be set to `Sophos`.
+    Initial setting for whether or not multiple av engines should be utilized to scan files. If this is enabled, the `agent_scanning_engine` variable must be set to `Sophos`.
     When set to `All`, every file will be scanned by both engines. 
     When set to `LargeFiles`, only files larger than 2GB will be scanned with `Sophos`, and 2GB and smaller will be scanned with `ClamAV`.
     Valid values: `Disabled`, `All`, `LargeFiles`
+    This value represents the initial setting upon deployment and can be modified via the console's UI after the initial deployment using Terraform.
   EOF
   type        = string
   default     = "Disabled"
@@ -232,13 +244,19 @@ variable "proxy_port" {
 }
 
 variable "eventbridge_notifications_enabled" {
-  description = "If true Proactive Notifications will also be sent to AWS EventBridge"
+  description = <<EOF
+  If true Proactive Notifications will also be sent to AWS EventBridge
+  This value represents the initial setting upon deployment and can be modified via the console's UI after the initial deployment using Terraform.
+  EOF
   type        = bool
   default     = false
 }
 
 variable "eventbridge_notifications_bus_name" {
-  description = "Enter the EventBridge bus name to use for notifications, if desired to be one other than default."
+  description = <<EOF
+  Enter the EventBridge bus name to use for notifications, if desired to be one other than default.
+  This value represents the initial setting upon deployment and can be modified via the console's UI after the initial deployment using Terraform.
+  EOF
   type        = string
   default     = "default"
 }
@@ -271,6 +289,11 @@ variable "quarantine_bucket_prefix" {
   default     = "cloudstoragesecquarantine"
 }
 
+variable "dashboard_reports_bucket_prefix" {
+  description = "Prefix for the Dashboard Reports bucket name"
+  type        = string
+  default     = "cloudstoragesecreports"
+}
 variable "api_request_scaling_policy_prefix" {
   description = "Prefix for the AutoScaling policy for the API Service."
   type        = string


### PR DESCRIPTION
CSS-1140 Include changes that were never moved to TF from https://github.com/cloudstoragesec/CloudStorageScan/pull/982/files# -- lets us delete the app from Deployment page. 

CSS-1135 - Make a note that some params are initial in description. Set AgentScanningEngine MultiEngineScanningMode lifecycle to ignore changes 

Include https://github.com/cloudstoragesec/antivirus-for-amazon-s3-terraform/pull/35 from old repo 

Fix CONSOLE_SECURITY_GROUP_ID. it should be a LoadBalancerSecurityGroup and not ConsoleSecurityGroup: 
https://github.com/cloudstoragesec/CloudStorageScan/blob/28bc62e30a00186bfee8543ee58cffb009cc27c0/Deployment/ConsoleCloudFormationTemplate.yaml#L3442

Add lb_arn to the output if lb is creted. 