### PR TITLE
Change CIDR variable to comma separated list.

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Example of a minimal deploy using only required inputs:
 module "cloud-storage-security" {
   source       = "cloudstoragesec/cloud-storage-security/aws"
   version      = "" # Latest version of the module from Provision Instructions
-  cidr         = "0.0.0.0/0" #The CIDR block which is allowed access to the CSS Console (e.g. 0.0.0.0/0 for open access)
+  cidr         = ["1.2.3.4/32", "4.5.6.7/24"] # Comma separated list of CIDR blocks that are allowed access to the CSS Console (default value is ["0.0.0.0/0"] for open access)
   email        = "admin@example.com" #The email address to be used for the initial admin account created for the CSS Console
   subnet_a_id  = "subnet-aaa" #A subnet ID within the VPC that may be used for ECS tasks for this deployment
   subnet_b_id  = "subnet-bbb" #A second subnet ID within the VPC that may be used for ECS tasks for this deployment. We recommend choosing subnets in different availability zones

--- a/security_group.tf
+++ b/security_group.tf
@@ -9,14 +9,14 @@ resource "aws_security_group" "console" {
     from_port   = 80
     to_port     = 80
     protocol    = "tcp"
-    cidr_blocks = ["${var.cidr}"]
+    cidr_blocks = var.cidr
   }
   ingress {
     description = "CloudStorageSec Console port 443 ingress"
     from_port   = 443
     to_port     = 443
     protocol    = "tcp"
-    cidr_blocks = ["${var.cidr}"]
+    cidr_blocks = var.cidr
   }
   egress {
     protocol    = "-1"
@@ -86,14 +86,14 @@ resource "aws_security_group" "load_balancer" {
     from_port   = 80
     to_port     = 80
     protocol    = "tcp"
-    cidr_blocks = ["${var.cidr}"]
+    cidr_blocks = var.cidr
   }
   ingress {
     description = "TLS from VPC"
     from_port   = 443
     to_port     = 443
     protocol    = "tcp"
-    cidr_blocks = ["${var.cidr}"]
+    cidr_blocks = var.cidr
   }
 
   egress {

--- a/variables.tf
+++ b/variables.tf
@@ -3,6 +3,7 @@ variable "vpc" {
 }
 
 variable "cidr" {
+  type        = list(string)
   description = "The CIDR block which is allowed access to the CSS Console (e.g. 0.0.0.0/0 for open access)"
 }
 


### PR DESCRIPTION
Change CIDR variable to comma separated list. Do not default the value so that customers explicitly define their allowed CIDR range(s).