### PR TITLE
CSS-1238 Add user attribute ignore lifecycle

### DIFF
--- a/cognito.tf
+++ b/cognito.tf
@@ -116,6 +116,11 @@ resource "aws_cognito_user" "admin" {
     email          = "${var.email}"
     email_verified = true
   }
+  lifecycle {
+    ignore_changes = [
+      attributes
+    ]
+  }
 }
 
 resource "aws_cognito_user_in_group" "admin" {


### PR DESCRIPTION
If you use the admin user for API access TF tries to "clean up" the attribute we set in cognito. Ignoring it 
Also applies to hide_welcome_msg