### PR TITLE
CSS-1435 Add permission to restore secrets.

### DIFF
--- a/iam.tf
+++ b/iam.tf
@@ -292,6 +292,7 @@ resource "aws_iam_role_policy" "console_task" {
           "secretsmanager:DescribeSecret",
           "secretsmanager:GetSecretValue",
           "secretsmanager:PutSecretValue",
+          "secretsmanager:RestoreSecret",
           "secretsmanager:TagResource",
           "sns:AddPermission",
           "sns:*Topic",


### PR DESCRIPTION
Add permission to restore secrets. Azure subscriptions with the same linked account name could not be re-linked due to the inability to restore the secret that was deleted after deleting the linked subscription.