### PR TITLE
CSS-1475 Customize SNS policy resources

### DIFF
--- a/ecs_task_definition.tf
+++ b/ecs_task_definition.tf
@@ -100,7 +100,6 @@ resource "aws_ecs_task_definition" "console" {
         { "name" : "APPLICATION_BUCKET_NAME", "value" : aws_s3_bucket.application.id },
         { "name" : "RETRY_COUNT", "value" : "5" },
         { "name" : "RETRY_MEDIAN_JITTER_DELAY", "value" : "1" },
-        { "name" : "AWS_BEDROCK_ENABLED", "value" : "${tostring(var.aws_bedrock_enabled)}" },
         { "name" : "ENABLED_REGIONS", "value" : "" },
       ]
       essential = true

--- a/ecs_task_definition.tf
+++ b/ecs_task_definition.tf
@@ -46,6 +46,7 @@ resource "aws_ecs_task_definition" "console" {
         { "name" : "DC_EVENT_BASED_SCAN_QUEUE_NAME", "value" : "${var.service_name}Queue-DC-${local.application_id}" },
         { "name" : "EFS_SCAN_QUEUE_NAME", "value" : "${var.service_name}Queue-EFS-${local.application_id}" },
         { "name" : "RETRO_SCAN_QUEUE_NAME", "value" : "${var.service_name}RetroQueue-${local.application_id}" },
+        { "name" : "SCANNED_ITEMS_QUEUE_NAME", "value" : aws_sqs_queue.scanned_items_queue.name },
         { "name" : "CONSOLE_TASK_NAME", "value" : "${var.service_name}Console-${local.application_id}" },
         { "name" : "CONSOLE_SERVICE_NAME", "value" : "${var.configure_load_balancer}" ? "${var.service_name}ConsoleService-LB-${local.application_id}" : "${var.service_name}ConsoleService-${local.application_id}" },
         { "name" : "CONSOLE_ROLE_ARN", "value" : aws_iam_role.console_task.arn },

--- a/iam.tf
+++ b/iam.tf
@@ -531,7 +531,7 @@ resource "aws_iam_role_policy_attachment" "dynamo_cmk_agent" {
 }
 
 resource "aws_iam_policy" "aws_bedrock" {
-  name  = "${var.service_name}ConsolePolicy-${local.application_id}-AwsBedrock"
+  name = "${var.service_name}ConsolePolicy-${local.application_id}-AwsBedrock"
   policy = jsonencode({
     Version = "2012-10-17"
     Statement = [

--- a/s3.tf
+++ b/s3.tf
@@ -4,8 +4,8 @@ resource "aws_s3_bucket" "application" {
 }
 
 resource "aws_s3_bucket_policy" "application_bucket_policy" {
-  bucket        = aws_s3_bucket.application.id
-  policy        = data.aws_iam_policy_document.application_bucket_policy_document.json
+  bucket = aws_s3_bucket.application.id
+  policy = data.aws_iam_policy_document.application_bucket_policy_document.json
 }
 
 data "aws_iam_policy_document" "application_bucket_policy_document" {

--- a/sqs.tf
+++ b/sqs.tf
@@ -1,0 +1,7 @@
+resource "aws_sqs_queue" "scanned_items_queue" {
+  name                       = "${var.service_name}-ScannedItems-${local.application_id}"
+  max_message_size           = 262144
+  message_retention_seconds  = 1209600
+  receive_wait_time_seconds  = 20
+  visibility_timeout_seconds = 1200
+}

--- a/variables.tf
+++ b/variables.tf
@@ -338,12 +338,6 @@ variable "api_request_scaling_policy_prefix" {
   default     = "ApiServiceRequestScaling"
 }
 
-variable "aws_bedrock_enabled" {
-  description = "Set to true if you would like to use Aws Bedrock features"
-  type        = bool
-  default     = false
-}
-
 variable "set_log_group_retention_policy" {
   description = "Whether we should set a retention policy on CSS created log groups. AWS Landing Zone Accelerator environments must set this to false."
   type        = bool
@@ -368,4 +362,16 @@ variable "product_listing" {
     condition     = contains(["AV", "DC", "S3", "MFT", "DLP", "EFS", "GenAi"], var.product_listing)
     error_message = "product_type must be one of 'AV', 'DC', 'S3', 'MFT', 'DLP', 'EFS', 'GenAi'."
   }
+}
+
+variable "sns_topic_policy_override_policy_documents" {
+  description = <<EOT
+    List of IAM policy documents that are merged together into the default SNS 'Notifications' Topic.
+    Passed in via `override_policy_documents` in `aws_iam_policy_document` data source.
+    Users should omit definition of the `resources` attribute in statement(s) as the module will
+    set resources to target only the 'Notifications' SNS topic.
+    https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document#override_policy_documents
+  EOT
+  type        = list(string)
+  default     = []
 }


### PR DESCRIPTION
- Allow customization of SNS notifications topic policy for customers who want to subscribe to the topic from another AWS account.
- Add ScannedItems queue for Azure support.