### PR TITLE
css-1535 Fix partition for gov support

### DIFF
--- a/iam.tf
+++ b/iam.tf
@@ -543,7 +543,7 @@ resource "aws_iam_policy" "aws_bedrock" {
         ]
         Effect   = "Allow"
         Sid      = "Bedrock"
-        Resource = "arn:aws:bedrock:*::foundation-model/*"
+        Resource = "arn:${data.aws_partition.current.partition}:bedrock:*::foundation-model/*"
       },
     ]
   })


### PR DESCRIPTION
Fix partition for the Bedrock IAM policy to allow apply in gov environment.

Policy size for Gov is currently set at 9,624 characters (where our limit is 10,240 characters). We don't hit the limit in terraform because of how it apply the changes and also because we haven't implemented least privilege in this repository yet.