### PR TITLE
feat: single sso integration

### DIFF
--- a/outputs.tf
+++ b/outputs.tf
@@ -67,3 +67,17 @@ output "cross_account_event_bridge_policy_name" {
   description = "Cross-Account Event Bridge Scanning Policy Name"
   value       = aws_iam_policy.event_bridge.name
 }
+
+# ---------------------------------------------------------------------------------------------------------------------
+# These outputs are provided for convenience to be used with SSO integration.
+# ---------------------------------------------------------------------------------------------------------------------
+
+output "cognito_user_pool_id" {
+  description = "Cognito User Pool ID"
+  value       = aws_cognito_user_pool.main.id
+}
+
+output "cognito_domain" {
+  description = "Cognito Domain"
+  value       = length(aws_cognito_user_pool_domain.main) > 0 ? "${aws_cognito_user_pool_domain.main[0].domain}.auth.${local.aws_region}.amazoncognito.com" : null
+}

--- a/variables.tf
+++ b/variables.tf
@@ -403,3 +403,82 @@ variable "azure_max_running_agents" {
   type        = number
   default     = 12
 }
+
+# ---------------------------------------------------------------------------------------------------------------------
+# OPTIONAL PARAMETERS FOR SSO INTEGRATION
+# These parameters have reasonable defaults.
+# ---------------------------------------------------------------------------------------------------------------------
+
+variable "cognito_domain_prefix" {
+  description = "This is the prefix of the Cognito domain."
+  type        = string
+  default     = null
+}
+
+variable "identity_provider_name" {
+  description = "The name of the identity provider"
+  type        = string
+  default     = null
+}
+
+variable "identity_provider_type" {
+  description = "The type of identity provider. Required if `identity_provider_name` is set."
+  type        = string
+  default     = "SAML"
+
+  validation {
+    condition     = contains(["SAML", "Facebook", "Google", "LoginWithAmazon", "SignInWithApple", "OIDC"], var.identity_provider_type)
+    error_message = "AWS API valid values: https://docs.aws.amazon.com/cognito-user-identity-pools/latest/APIReference/API_CreateIdentityProvider.html#CognitoUserPools-CreateIdentityProvider-request-ProviderType"
+  }
+}
+
+
+variable "identity_provider_details" {
+  description = "The map of identity detials, such as access token or 'MetadataURL'"
+  type        = map(string)
+  default     = {}
+}
+
+variable "identity_attribute_mapping" {
+  description = "The map of attribute mapping of user pool attributes."
+  type        = map(string)
+  default     = {}
+}
+
+variable "client_callback_urls" {
+  description = "List of allowed callback URLs for the identity providers."
+  type        = list(string)
+  default     = []
+}
+
+variable "client_logout_urls" {
+  description = "List of allowed logout URLs for the identity providers."
+  type        = list(string)
+  default     = []
+}
+
+variable "client_allowed_oauth_flows" {
+  description = "List of allowed OAuth flows for the identity providers."
+  type        = list(string)
+  default     = []
+
+  validation {
+    condition = alltrue([
+      for item in var.client_allowed_oauth_flows : contains(["code", "implicit", "client_credentials"], item)
+    ])
+    error_message = "Allowed values are 'code', 'implicit', 'client_credentials'"
+  }
+}
+
+variable "client_allowed_oauth_scopes" {
+  description = "List of allowed OAuth scopes for the identity providers."
+  type        = list(string)
+  default     = []
+
+  validation {
+    condition = alltrue([
+      for item in var.client_allowed_oauth_scopes : contains(["openid", "email", "phone", "profile", "aws.cognito.signin.user.admin"], item)
+    ])
+    error_message = "Allowed values are 'openid', 'email', 'phone', 'profile', 'aws.cognito.signin.user.admin'"
+  }
+}


### PR DESCRIPTION
# What

- feat: adds resources and configurability to setup SSO integration 

# Why

- module consumers should be able to setup SSO 
- as is users are unable to modify the existing cognito user pool client to set this up

# Example Usage

```
module "cloud-storage--security" {
  source  = "cloudstoragesec/cloud-storage-security/aws"
...

  cognito_domain_prefix = "my-css-auth"
  identity_provider_name = "EntraID"
  identity_provider_type = "SAML"
  identity_provider_details = {
    MetadataURL = "https://login.microsoftonline.com/xxxxxxxx/federationmetadata.xml?appid=xxxxxxxxx"
  }
  client_callback_urls = [ "https://my-css-123456.cloudstoragesecapp.com/" ]
  client_logout_urls = [ "https://my-css-123456.cloudstoragesecapp.com/" ]
  client_allowed_oauth_flows = ["code", "implicit"]
  client_allowed_oauth_scopes = ["openid", "email"]
}
```