### PR TITLE
Fix css-2043 using eventbridge notifications

### DIFF
--- a/iam.tf
+++ b/iam.tf
@@ -877,7 +877,7 @@ resource "aws_iam_role_policy_attachment" "event_bridge" {
 }
 
 resource "aws_iam_policy" "proactive_notifications_event_bridge" {
-  count = local.create_custom_event_bus ? 1 : 0
+  count = var.eventbridge_notifications_enabled ? 1 : 0
   name  = "ProactiveNotificationsEventBridgePolicy-${local.application_id}"
   policy = jsonencode({
     Version = "2012-10-17"
@@ -890,7 +890,7 @@ resource "aws_iam_policy" "proactive_notifications_event_bridge" {
           "events:DescribeEventBus"
         ]
         Resource = [
-          "arn:${data.aws_partition.current.partition}:events:*:${local.account_id}:event-bus/*${var.eventbridge_notifications_bus_name}"
+          "arn:${data.aws_partition.current.partition}:events:*:${local.account_id}:event-bus/${var.eventbridge_notifications_bus_name}"
         ]
       }
     ]
@@ -898,13 +898,13 @@ resource "aws_iam_policy" "proactive_notifications_event_bridge" {
 }
 
 resource "aws_iam_role_policy_attachment" "custom_event_bridge_console" {
-  count      = local.create_custom_event_bus ? 1 : 0
+  count      = var.eventbridge_notifications_enabled ? 1 : 0
   role       = aws_iam_role.console_task.name
   policy_arn = aws_iam_policy.proactive_notifications_event_bridge[0].arn
 }
 
 resource "aws_iam_role_policy_attachment" "custom_event_bridge_agent" {
-  count      = local.create_custom_event_bus ? 1 : 0
+  count      = var.eventbridge_notifications_enabled ? 1 : 0
   role       = aws_iam_role.agent_task.name
   policy_arn = aws_iam_policy.proactive_notifications_event_bridge[0].arn
 }

--- a/ssm.tf
+++ b/ssm.tf
@@ -361,18 +361,12 @@ resource "aws_ssm_parameter" "event_bridge_notifications_enabled" {
   name  = "/${local.ssm_path_prefix}/Config/EventBridgeNotificationsEnabled"
   type  = "String"
   value = var.eventbridge_notifications_enabled
-  lifecycle {
-    ignore_changes = [value]
-  }
 }
 
 resource "aws_ssm_parameter" "event_bridge_notifications_bus_name" {
   name  = "/${local.ssm_path_prefix}/Config/EventBridgeNotificationsBusName"
   type  = "String"
   value = var.eventbridge_notifications_bus_name
-  lifecycle {
-    ignore_changes = [value]
-  }
 }
 
 resource "aws_ssm_parameter" "set_log_group_retention_policy" {


### PR DESCRIPTION
Changes behavior of Proactive Notifications with EventBridge, 
Add necessary permissions to both custom and default event bus
Got rid of ignoring the changes in ssm when the behavior is changed.
