### PR TITLE
CloudWatch log retention configurable via log_retention_days variable

### DIFF
--- a/cloudwatch.tf
+++ b/cloudwatch.tf
@@ -3,7 +3,7 @@ resource "aws_cloudwatch_log_group" "main" {
   tags = merge({ (local.application_tag_key) = "ConsoleTargetGroup" },
     var.custom_resource_tags
   )
-  retention_in_days = var.set_log_group_retention_policy ? 7 : null
+  retention_in_days = var.set_log_group_retention_policy ? var.log_retention_days : null
 }
 
 resource "aws_cloudwatch_metric_alarm" "health_check_console" {

--- a/variables.tf
+++ b/variables.tf
@@ -440,3 +440,9 @@ variable "use_fips_endpoints" {
   type        = bool
   default     = false
 }
+
+variable "log_retention_days" {
+  description = "Number of days to retain logs"
+  type        = number
+  default     = 7
+}


### PR DESCRIPTION
Added a new variable `log_retention_days` to allow users to customize the retention
period of CloudWatch log groups. Defaults to 7 days.