### PR TITLE
fix: align product_listing validation with application's ProductListing enum

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -453,8 +453,8 @@ variable "product_listing" {
   type        = string
   default     = "AV"
   validation {
-    condition     = contains(["AV", "DC", "S3", "MFT", "DLP", "EFS", "GenAi", "BYOL"], var.product_listing)
-    error_message = "product_type must be one of 'AV', 'DC', 'S3', 'MFT', 'DLP', 'EFS', 'GenAi', BYOL'."
+    condition     = contains(["AV", "DC", "S3", "MFT", "EFS", "BYOL"], var.product_listing)
+    error_message = "product_listing must be one of 'AV', 'DC', 'S3', 'MFT', 'EFS', 'BYOL'."
   }
 }
 


### PR DESCRIPTION
Remove 'DLP' and 'GenAi' from allowed values — the application does not accept these. The DLP marketplace listing corresponds to 'DC'. Also fix the error message which incorrectly referenced 'product_type'.