### PR TITLE
Adds variable to set LFS volume type

### DIFF
--- a/ecs_service.tf
+++ b/ecs_service.tf
@@ -141,22 +141,3 @@ resource "aws_lb" "main" {
     }
   }
 }
-
-resource "terraform_data" "console_restart_on_ssm_change" {
-  count = var.api_agent_deploy ? 1 : 0
-
-  triggers_replace = [
-    aws_ssm_parameter.api_agent_scanning_engine[0].value,
-    aws_ssm_parameter.api_agent_multi_engine_scanning_mode[0].value,
-    aws_ssm_parameter.api_agent_min_agents[0].value,
-    aws_ssm_parameter.api_agent_max_agents[0].value,
-    aws_ssm_parameter.api_agent_cpu[0].value,
-    aws_ssm_parameter.api_agent_memory[0].value,
-    aws_ssm_parameter.api_agent_disk_size[0].value,
-    aws_ssm_parameter.api_agent_enable_asynchronous_scanning[0].value,
-  ]
-
-  provisioner "local-exec" {
-    command = "aws ecs update-service --cluster ${aws_ecs_cluster.main.name} --service ${local.ecs_service_name} --force-new-deployment --region ${local.aws_region}"
-  }
-}

--- a/ecs_task_definition.tf
+++ b/ecs_task_definition.tf
@@ -98,6 +98,7 @@ resource "aws_ecs_task_definition" "console" {
         { "name" : "PRODUCT_MODE", "value" : "${local.product_mode}" },
         { "name" : "TEMPLATE_VARIATION", "value" : "default" },
         { "name" : "DEPLOYMENT_TYPE", "value" : "terraform" },
+        { "name" : "LARGE_FILE_VOLUME_TYPE", "value" : var.large_file_volume_type },
         { "name" : "BUCKETS_TO_PROTECT", "value" : "${var.buckets_to_protect}" },
         { "name" : "LOG_LEVEL", "value" : "Info" },
         { "name" : "APPLICATION_BUCKET_NAME", "value" : aws_s3_bucket.application.id },

--- a/locals.tf
+++ b/locals.tf
@@ -2,8 +2,8 @@ locals {
   # Terraform module and the associated app version are tightly coupled for compatibility. 
   # Specified 'image_version' corresponds to a tested combination of Terraform and app release.
   # Avoid manually changing the 'image_version' unless you have explicit instructions to do so.
-  image_version_console   = "v9.09.000"
-  image_version_agent     = "v9.09.000"
+  image_version_console   = "v9.09.001"
+  image_version_agent     = "v9.09.001"
   ecr_account             = coalesce(var.ecr_account, local.is_gov ? "822167061992" : "564477214187")
   console_image_url       = "${local.ecr_account}.dkr.ecr.${local.aws_region}.amazonaws.com/cloudstoragesecurity/console:${local.image_version_console}"
   agent_image_url         = "${local.ecr_account}.dkr.ecr.<region>.amazonaws.com/cloudstoragesecurity/agent:${local.image_version_agent}"

--- a/variables.tf
+++ b/variables.tf
@@ -618,3 +618,17 @@ variable "api_agent_enable_asynchronous_scanning" {
   type        = bool
   default     = false
 }
+
+variable "large_file_volume_type" {
+  description = <<EOF
+    (Optional) EBS volume type used by the Large File Scan (LFS) Fargate task.
+    Defaults to `gp2`. Set to `gp3` when an SCP or organizational policy requires gp3 volumes.
+    Valid values: `gp2`, `gp3`
+  EOF
+  type        = string
+  default     = "gp2"
+  validation {
+    condition     = contains(["gp2", "gp3"], var.large_file_volume_type)
+    error_message = "`large_file_volume_type` must be one of 'gp2', 'gp3'."
+  }
+}


### PR DESCRIPTION
## Summary

- Adds a new optional `large_file_volume_type` input variable (defaults to `gp2`, validated against `gp2`/`gp3`).
- Wires it into the console task definition as the `LARGE_FILE_VOLUME_TYPE` environment variable, consumed by the LFS Fargate path in the console app.

Allows deployments under SCPs that forbid `gp2` (e.g. policies enforcing `gp3`) to switch the LFS scan EBS volume type from `main.tf` without code changes.

Paired with CSS repo PR introducing the `LARGE_FILE_VOLUME_TYPE` env var.