### PR TITLE
Css Resources - Grant access to all replicas of a multi-region S3 CMK (CSS-3135)

### DIFF
--- a/locals.tf
+++ b/locals.tf
@@ -20,11 +20,18 @@ locals {
   use_s3_cmk              = var.s3_cmk_key_arn != "default"
   use_lb_subnets          = var.lb_subnet_a_id != null && var.lb_subnet_b_id != null
   ebs_volume_encryption_kms_key = var.ebs_volume_encryption && var.ebs_volume_encryption_kms_key_id != "default" ? var.ebs_volume_encryption_kms_key_id : null
+  # When the S3 CMK is a multi-region key, the agents may be running in a different
+  # region than the supplied ARN; grant access to every replica by adding a
+  # region-wildcarded ARN alongside the original.
+  s3_cmk_arn_parts  = local.use_s3_cmk ? split(":", var.s3_cmk_key_arn) : []
+  s3_cmk_is_mrk_arn = length(local.s3_cmk_arn_parts) == 6 && local.s3_cmk_arn_parts[0] == "arn" && local.s3_cmk_arn_parts[2] == "kms" && startswith(local.s3_cmk_arn_parts[5], "key/mrk-")
+  s3_cmk_mrk_wildcard_arn = local.s3_cmk_is_mrk_arn ? "arn:${local.s3_cmk_arn_parts[1]}:kms:*:${local.s3_cmk_arn_parts[4]}:${local.s3_cmk_arn_parts[5]}" : null
   custom_key_list = concat(compact([
     var.dynamo_cmk_key_arn,
     var.sns_cmk_key_arn,
     var.sqs_cmk_key_arn,
     var.s3_cmk_key_arn,
+    local.s3_cmk_mrk_wildcard_arn,
     local.ebs_volume_encryption_kms_key
   ]), var.sns_cmk_keys_arn, var.sqs_cmk_keys_arn)
   application_tag_key           = (join("-", ["${var.service_name}", "${local.application_id}"]))

--- a/variables.tf
+++ b/variables.tf
@@ -290,6 +290,7 @@ variable "s3_cmk_key_arn" {
   description = <<EOF
     Optional ARN for the CMK that should be used for the AWS KMS encryption for the S3 Buckets.
     The default AWS-managed key will be applied when this value is not specified.
+    Multi-region keys (`mrk-...`) are supported - supply any replica's ARN.
   EOF
   type        = string
   default     = "default"


### PR DESCRIPTION
## Summary

- When `s3_cmk_key_arn` is a multi-region KMS key ARN (`key/mrk-...`), derive a region-wildcarded sibling ARN and include both in `custom_key_list` so agents in any region can use their **local replica** instead of failing IAM evaluation against the single user-supplied ARN.
- Update `variables.tf` description for `s3_cmk_key_arn` to note multi-region key support.

Paired with the console-side fix in CloudStorageScan branch `css-3135-support-multi-region-kms-keys` which stores the bare key id (not the ARN) on quarantine bucket default SSE and rewrites existing buckets on upgrade. Linear: CSS-3135.

## Test plan

- [x] `terraform plan` against a deployment using a non-MRK ARN — no diff in IAM resources.
- [x] `terraform plan` against a deployment using an MRK ARN — `custom_key_list` gains the `arn:aws:kms:*:<acct>:key/mrk-...` sibling.
- [x] `terraform plan` with `s3_cmk_key_arn = "default"` — no MRK locals evaluated, no IAM change.
- [x] Apply on a multi-region setup (console + key in us-east-1, agent + quarantine bucket in us-east-2) — agent can write to the quarantine bucket in its own region.