### PR TITLE
chore: bump image versions up to v9.09.002

### DIFF
--- a/locals.tf
+++ b/locals.tf
@@ -2,8 +2,8 @@ locals {
   # Terraform module and the associated app version are tightly coupled for compatibility. 
   # Specified 'image_version' corresponds to a tested combination of Terraform and app release.
   # Avoid manually changing the 'image_version' unless you have explicit instructions to do so.
-  image_version_console   = "v9.09.001"
-  image_version_agent     = "v9.09.001"
+  image_version_console   = "v9.09.002"
+  image_version_agent     = "v9.09.002"
   ecr_account             = coalesce(var.ecr_account, local.is_gov ? "822167061992" : "564477214187")
   console_image_url       = "${local.ecr_account}.dkr.ecr.${local.aws_region}.amazonaws.com/cloudstoragesecurity/console:${local.image_version_console}"
   agent_image_url         = "${local.ecr_account}.dkr.ecr.<region>.amazonaws.com/cloudstoragesecurity/agent:${local.image_version_agent}"


### PR DESCRIPTION
bump image versions up to v9.09.002