### PR TITLE
Add SSO possibility through terraform params

### DIFF
--- a/cognito.tf
+++ b/cognito.tf
@@ -147,10 +147,47 @@ resource "aws_cognito_user_pool" "main" {
 }
 
 
+resource "aws_cognito_user_pool_domain" "sso" {
+  count        = local.enable_sso ? 1 : 0
+  domain       = local.sso_domain_prefix
+  user_pool_id = aws_cognito_user_pool.main.id
+}
+
+resource "aws_cognito_identity_provider" "saml" {
+  count         = local.enable_sso ? 1 : 0
+  user_pool_id  = aws_cognito_user_pool.main.id
+  provider_name = var.sso_provider_name
+  provider_type = "SAML"
+  provider_details = {
+    MetadataURL = var.sso_metadata_url
+    IDPSignout  = "true"
+  }
+  attribute_mapping = {
+    email = "http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress"
+  }
+}
+
 resource "aws_cognito_user_pool_client" "main" {
-  name            = "${var.service_name}UserPoolClient-${local.application_id}"
-  user_pool_id    = aws_cognito_user_pool.main.id
-  generate_secret = true
+  name                     = "${var.service_name}UserPoolClient-${local.application_id}"
+  user_pool_id             = aws_cognito_user_pool.main.id
+  generate_secret          = true
+  enable_token_revocation  = true
+
+  allowed_oauth_flows_user_pool_client = local.enable_sso ? true : null
+  allowed_oauth_flows                  = local.enable_sso ? ["code", "implicit"] : null
+  allowed_oauth_scopes                 = local.enable_sso ? ["openid", "email", "profile"] : null
+  supported_identity_providers         = local.enable_sso ? ["COGNITO", var.sso_provider_name] : null
+  callback_urls                        = local.enable_sso ? [local.console_url] : null
+  logout_urls                          = local.enable_sso ? [local.console_url] : null
+
+  depends_on = [aws_cognito_identity_provider.saml]
+
+  lifecycle {
+    precondition {
+      condition     = (var.sso_provider_name == null) == (var.sso_metadata_url == null)
+      error_message = "sso_provider_name and sso_metadata_url must both be set or both be null."
+    }
+  }
 }
 
 resource "aws_cognito_user_group" "admins" {

--- a/locals.tf
+++ b/locals.tf
@@ -68,4 +68,6 @@ locals {
     var.api_agent_scanning_engine
   )
   api_agent_multi_engine_scanning_mode = var.api_agent_scanning_engine == "All" ? "All" : "Disabled"
+  enable_sso                           = var.sso_provider_name != null && var.sso_metadata_url != null
+  sso_domain_prefix                    = "css-${local.account_id}-${local.application_id}"
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -82,3 +82,22 @@ output "load_balancer_security_group_id" {
   description = "ID of the Load Balancer security group (used when load balancer is configured)"
   value       = var.configure_load_balancer ? aws_security_group.load_balancer[0].id : null
 }
+
+# ---------------------------------------------------------------------------------------------------------------------
+# SSO Outputs (only populated when sso_provider_name and sso_metadata_url are set)
+# ---------------------------------------------------------------------------------------------------------------------
+
+output "sso_saml_entity_id" {
+  description = "SAML Entity ID (Audience / Identifier) to register in your Identity Provider. Null when SSO is not enabled."
+  value       = local.enable_sso ? "urn:amazon:cognito:sp:${aws_cognito_user_pool.main.id}" : null
+}
+
+output "sso_saml_reply_url" {
+  description = "SAML Reply URL (Assertion Consumer Service URL) to register in your Identity Provider. Null when SSO is not enabled."
+  value       = local.enable_sso ? "https://${local.sso_domain_prefix}.auth.${local.aws_region}.amazoncognito.com/saml2/idpresponse" : null
+}
+
+output "sso_hosted_ui_sign_in_url" {
+  description = "Cognito Hosted UI sign-in URL for testing SSO directly. Null when SSO is not enabled."
+  value       = local.enable_sso ? "https://${local.sso_domain_prefix}.auth.${local.aws_region}.amazoncognito.com/login?response_type=code&client_id=${aws_cognito_user_pool_client.main.id}&identity_provider=${var.sso_provider_name}" : null
+}

--- a/variables.tf
+++ b/variables.tf
@@ -632,3 +632,38 @@ variable "large_file_volume_type" {
     error_message = "`large_file_volume_type` must be one of 'gp2', 'gp3'."
   }
 }
+
+# ---------------------------------------------------------------------------------------------------------------------
+# SAML SSO (OPTIONAL)
+# ---------------------------------------------------------------------------------------------------------------------
+
+variable "sso_provider_name" {
+  description = <<EOF
+    Optional. Logical name for the SAML Identity Provider in Cognito. This name is what the CSS Console
+    renders on the sign-in button (e.g. "AzureAD", "Okta", "Auth0"). No spaces. Must start with a
+    letter and contain only letters, numbers, dots, underscores, or hyphens (3-32 chars total).
+    Leave null (default) to deploy without SSO.
+    Both sso_provider_name and sso_metadata_url must be set together.
+  EOF
+  type    = string
+  default = null
+  validation {
+    condition     = var.sso_provider_name == null || can(regex("^[A-Za-z][A-Za-z0-9._-]{2,31}$", var.sso_provider_name))
+    error_message = "sso_provider_name must start with a letter and contain only letters, numbers, dots, underscores, or hyphens (3-32 chars total)."
+  }
+}
+
+variable "sso_metadata_url" {
+  description = <<EOF
+    Optional. SAML federation metadata URL provided by the Identity Provider (e.g. Entra ID
+    "App Federation Metadata URL", Okta metadata URL, Auth0 Usage tab metadata URL).
+    Required when sso_provider_name is set. Must be an HTTPS URL.
+    Both sso_provider_name and sso_metadata_url must be set together.
+  EOF
+  type    = string
+  default = null
+  validation {
+    condition     = var.sso_metadata_url == null || can(regex("^https://", var.sso_metadata_url))
+    error_message = "sso_metadata_url must be a valid HTTPS URL."
+  }
+}


### PR DESCRIPTION
## Summary

- Adds two optional variables (`sso_provider_name`, `sso_metadata_url`) that, when set together, automate the full Cognito SAML SSO setup at deploy time — hosted domain, SAML identity provider, and User Pool Client OAuth configuration
- Derives the Cognito domain prefix and callback/logout URLs automatically from the existing deployment context, so no extra configuration is needed beyond the two variables
- Adds three outputs (`sso_saml_entity_id`, `sso_saml_reply_url`, `sso_hosted_ui_sign_in_url`) giving users the exact values to paste into their IdP (Entra ID, Okta, Auth0, etc.)
- Enables `enable_token_revocation` on the User Pool Client for all deployments

## Test plan

- [x] `terraform plan` with both vars unset produces no diff on the Cognito client (existing deployments unaffected)
- [x] `terraform apply` with both vars set creates `aws_cognito_user_pool_domain`, `aws_cognito_identity_provider`, and updates the pool client with OAuth flows/scopes/callback URLs
- [x] Outputs `sso_saml_entity_id` and `sso_saml_reply_url` match what was registered in the IdP
- [x] SSO sign-in button appears on the CSS Console and end-to-end login succeeds
- [x] Setting only one of the two vars produces a clear `precondition` error at plan time
- [x] Clearing both vars removes the SSO resources and reverts the pool client

## Related

Mirrors the equivalent changes made to `ConsoleCloudFormationTemplate.yaml` and `ConsoleCloudFormationTemplate-BYOL.yaml`.

Closes CSS-3463