### PR TITLE
CSS-3758 - add optional permissions_boundary_arn for IAM roles

### DIFF
--- a/iam.tf
+++ b/iam.tf
@@ -1,6 +1,7 @@
 
 resource "aws_iam_role" "appconfig_agent_configuration_document" {
-  name = "AppConfigAgentConfigurationDocumentRole-${local.application_id}"
+  name                 = "AppConfigAgentConfigurationDocumentRole-${local.application_id}"
+  permissions_boundary = var.permissions_boundary_arn
   assume_role_policy = jsonencode({
     Version = "2012-10-17"
     Statement = [
@@ -37,7 +38,8 @@ resource "aws_iam_role_policy" "appconfig_agent_configuration_document" {
 }
 
 resource "aws_iam_role" "user_pool_sns" {
-  name = "${var.service_name}UserPoolRole-${local.application_id}"
+  name                 = "${var.service_name}UserPoolRole-${local.application_id}"
+  permissions_boundary = var.permissions_boundary_arn
   assume_role_policy = jsonencode({
     Version = "2012-10-17"
     Statement = [
@@ -73,8 +75,9 @@ resource "aws_iam_role_policy" "user_pool_sns" {
 }
 
 resource "aws_iam_role" "console_task" {
-  name        = "${var.service_name}ConsoleRole-${local.application_id}"
-  description = "Console ECS Task IAM Role"
+  name                 = "${var.service_name}ConsoleRole-${local.application_id}"
+  description          = "Console ECS Task IAM Role"
+  permissions_boundary = var.permissions_boundary_arn
   assume_role_policy = jsonencode({
     Version = "2012-10-17"
     Statement = [
@@ -560,7 +563,8 @@ resource "aws_iam_role_policy_attachment" "aws_bedrock_console" {
 }
 
 resource "aws_iam_role" "agent_task" {
-  name = "${var.service_name}AgentRole-${local.application_id}"
+  name                 = "${var.service_name}AgentRole-${local.application_id}"
+  permissions_boundary = var.permissions_boundary_arn
   assume_role_policy = jsonencode({
     Version = "2012-10-17"
     Statement = [
@@ -709,7 +713,8 @@ resource "aws_iam_role_policy" "agent_task" {
 
 #This is exec role
 resource "aws_iam_role" "execution" {
-  name = "${var.service_name}ExecutionRole-${local.application_id}"
+  name                 = "${var.service_name}ExecutionRole-${local.application_id}"
+  permissions_boundary = var.permissions_boundary_arn
   assume_role_policy = jsonencode({
     Version = "2012-10-17"
     Statement = [
@@ -731,7 +736,8 @@ resource "aws_iam_role" "execution" {
 }
 
 resource "aws_iam_role" "ec2_container" {
-  name = "${var.service_name}Ec2ContainerRole-${local.application_id}"
+  name                 = "${var.service_name}Ec2ContainerRole-${local.application_id}"
+  permissions_boundary = var.permissions_boundary_arn
   assume_role_policy = jsonencode({
     Version = "2012-10-17"
     Statement = [
@@ -836,8 +842,9 @@ resource "aws_iam_instance_profile" "ec2_container" {
 }
 
 resource "aws_iam_role" "event_bridge" {
-  count = local.create_event_bridge_role ? 1 : 0
-  name  = local.event_bridge_role_name
+  count                = local.create_event_bridge_role ? 1 : 0
+  name                 = local.event_bridge_role_name
+  permissions_boundary = var.permissions_boundary_arn
   assume_role_policy = jsonencode({
     Version = "2012-10-17"
     Statement = [

--- a/modules/linked-account/main.tf
+++ b/modules/linked-account/main.tf
@@ -10,6 +10,7 @@ terraform {
 resource "aws_iam_role" "remote_access" {
   count = local.create_cross_account_role ? 1 : 0
   name = local.cross_account_role_name
+  permissions_boundary = var.permissions_boundary_arn
   assume_role_policy = jsonencode({
     Version = "2012-10-17"
     Statement = [
@@ -269,6 +270,7 @@ resource "aws_iam_role_policy_attachment" "remote_access_ec2_management" {
 resource "aws_iam_role" "event_bridge_role" {
   count = local.create_event_bridge_role ? 1 : 0
   name = local.cross_account_event_bridge_role_name
+  permissions_boundary = var.permissions_boundary_arn
   assume_role_policy = jsonencode({
     Version = "2012-10-17"
     Statement = [

--- a/modules/linked-account/variables.tf
+++ b/modules/linked-account/variables.tf
@@ -106,3 +106,13 @@ variable "create_workdocs_permissions" {
   type        = bool
   default     = false
 }
+
+variable "permissions_boundary_arn" {
+  description = <<EOF
+    Optional ARN of an IAM managed policy to attach as a permissions boundary on all IAM
+    roles this module creates. Leave null (default) if your account does not require a
+    permissions boundary.
+  EOF
+  type    = string
+  default = null
+}

--- a/modules/organizations/main.tf
+++ b/modules/organizations/main.tf
@@ -18,6 +18,7 @@ check "mutually_exclusive_deployment_targets" {
 resource "aws_iam_role" "organizations_access" {
   name        = local.role_name
   description = "Allows the Cloud Storage Scan console to read AWS Organizations structure for automatic account discovery"
+  permissions_boundary = var.permissions_boundary_arn
 
   assume_role_policy = jsonencode({
     Version = "2012-10-17"
@@ -104,6 +105,7 @@ resource "aws_cloudformation_stack_set" "linked_accounts" {
     CrossAccountPolicyName           = var.cross_account_policy_name
     CrossAccountEventBridgeRoleName  = var.cross_account_event_bridge_role_name
     CrossAccountEventBridgePolicyName = var.cross_account_event_bridge_policy_name
+    PermissionsBoundaryArn            = coalesce(var.permissions_boundary_arn, "")
   }
 
   capabilities = ["CAPABILITY_NAMED_IAM"]

--- a/modules/organizations/variables.tf
+++ b/modules/organizations/variables.tf
@@ -122,3 +122,14 @@ variable "stackset_retain_on_removal" {
   type        = bool
   default     = false
 }
+
+variable "permissions_boundary_arn" {
+  description = <<EOF
+    Optional ARN of an IAM managed policy to attach as a permissions boundary on the IAM
+    role this module creates, and passed through as the LinkedAccount CFT StackSet's
+    PermissionsBoundaryArn parameter for org-wide rollout. Leave null (default) if your
+    account does not require a permissions boundary.
+  EOF
+  type    = string
+  default = null
+}

--- a/variables.tf
+++ b/variables.tf
@@ -668,3 +668,13 @@ variable "sso_metadata_url" {
     error_message = "sso_metadata_url must be a valid HTTPS URL."
   }
 }
+
+variable "permissions_boundary_arn" {
+  description = <<EOF
+    Optional ARN of an IAM managed policy to attach as a permissions boundary on all IAM
+    roles this module creates. Leave null (default) if your account does not require a
+    permissions boundary.
+  EOF
+  type    = string
+  default = null
+}


### PR DESCRIPTION
Adds a permissions_boundary_arn variable and applies it as the permissions_boundary on every IAM role created by the root module and the linked-account/organizations submodules, mirroring the same support added to the CloudFormation templates. Defaults to null (no boundary).

The organizations module also passes it through as the PermissionsBoundaryArn parameter on its LinkedAccount CFT StackSet, so the boundary propagates to linked accounts deployed org-wide.